### PR TITLE
Notify Camunda of failure on uncaught exceptions

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ django-appconf==1.0.3     # via django-axes, django-timeline-logger
 django-auth-adfs-db==0.2.0
 django-auth-adfs==1.3.1   # via django-auth-adfs-db
 django-axes==5.2.2
-django-camunda==0.4.0
+django-camunda==0.5.1
 django-choices==1.7.1
 django-compat==1.0.15     # via django-hijack, django-hijack-admin
 django-docutils==0.4.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -23,7 +23,7 @@ django-appconf==1.0.3
 django-auth-adfs-db==0.2.0
 django-auth-adfs==1.3.1
 django-axes==5.2.2
-django-camunda==0.4.0
+django-camunda==0.5.1
 django-choices==1.7.1
 django-compat==1.0.15
 django-docutils==0.4.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -28,7 +28,7 @@ django-appconf==1.0.3
 django-auth-adfs-db==0.2.0
 django-auth-adfs==1.3.1
 django-axes==5.2.2
-django-camunda==0.4.0
+django-camunda==0.5.1
 django-choices==1.7.1
 django-compat==1.0.15
 django-debug-toolbar==2.1

--- a/src/bptl/camunda/tasks.py
+++ b/src/bptl/camunda/tasks.py
@@ -11,6 +11,7 @@ from bptl.tasks.api import execute
 from bptl.utils.constants import Statuses
 
 from ..celery import app
+from .utils import fail_task
 
 logger = get_task_logger(__name__)
 
@@ -55,7 +56,7 @@ def task_execute_and_complete(fetched_task_id):
             exc,
             exc_info=True,
         )
-
+        fail_task(fetched_task)
         return
 
     logger.info("Task %r is executed", fetched_task_id)
@@ -70,7 +71,6 @@ def task_execute_and_complete(fetched_task_id):
             exc,
             exc_info=True,
         )
-
         return
 
     logger.info("Task %r is completed", fetched_task_id)

--- a/src/bptl/camunda/tests/test_celery_tasks.py
+++ b/src/bptl/camunda/tests/test_celery_tasks.py
@@ -37,9 +37,12 @@ class RouteTaskTests(TestCase):
         m_execute.assert_called_once_with(task)
         m_complete.assert_called_once_with(task)
 
+    @patch("bptl.camunda.tasks.fail_task")
     @patch("bptl.camunda.tasks.complete")
     @patch("bptl.camunda.tasks.execute", side_effect=Exception("execution is failed"))
-    def test_task_execute_and_complete_fail_execute(self, m_execute, m_complete):
+    def test_task_execute_and_complete_fail_execute(
+        self, m_execute, m_complete, m_fail_task
+    ):
         @save_and_log()
         def new_execute(task):
             raise Exception("execution is failed")
@@ -56,6 +59,7 @@ class RouteTaskTests(TestCase):
 
         m_execute.assert_called_once_with(task)
         m_complete.assert_not_called()
+        m_fail_task.assert_called_once_with(task)
 
     @patch("bptl.camunda.tasks.complete", side_effect=Exception("completion failed"))
     @patch("bptl.camunda.tasks.execute")
@@ -77,7 +81,7 @@ class RouteTaskTests(TestCase):
         m_complete.assert_called_once_with(task)
 
     @patch("bptl.camunda.tasks.logger.warning")
-    def test_task_execute_alreaty_run(self, m_logger):
+    def test_task_execute_already_run(self, m_logger):
         task = ExternalTaskFactory.create(status=Statuses.in_progress)
 
         task_execute_and_complete(task.id)

--- a/src/bptl/camunda/tests/test_execute_task.py
+++ b/src/bptl/camunda/tests/test_execute_task.py
@@ -1,5 +1,6 @@
 import json
 from io import StringIO
+from unittest.mock import patch
 
 from django.core.management import call_command
 from django.test import TestCase
@@ -143,7 +144,8 @@ class ExecuteCommandTests(TestCase):
             },
         )
 
-    def test_execute_fail(self, m):
+    @patch("bptl.camunda.tasks.fail_task")
+    def test_execute_fail(self, m, mock_fail_task):
         task = ExternalTaskFactory.create(
             topic_name="zaak-initialize",
             variables={
@@ -168,3 +170,5 @@ class ExecuteCommandTests(TestCase):
         task.refresh_from_db()
         self.assertEqual(task.status, Statuses.failed)
         self.assertTrue(task.execution_error.strip().endswith("some connection error"))
+
+        mock_fail_task.assert_called_once_with(task)

--- a/src/bptl/camunda/tests/test_mark_failure.py
+++ b/src/bptl/camunda/tests/test_mark_failure.py
@@ -1,0 +1,92 @@
+"""
+Test marking tasks as failed to Camunda.
+
+Example requests and response taken from
+https://docs.camunda.org/manual/7.12/reference/rest/external-task/post-complete/
+"""
+from django.test import TestCase
+
+import requests_mock
+from django_camunda.models import CamundaConfig
+
+from ..models import ExternalTask
+from ..utils import fail_task
+
+
+@requests_mock.Mocker()
+class CompleteTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        config = CamundaConfig.get_solo()
+        config.root_url = "https://some.camunda.com"
+        config.rest_api_path = "engine-rest/"
+        config.save()
+
+        cls.task = ExternalTask.objects.create(
+            worker_id="test-worker-id",
+            task_id="test-task-id",
+            execution_error="\n".join(["Line 1", "Line 2"]),
+        )
+
+    def test_fail_task_with_reason(self, m):
+        m.post(
+            "https://some.camunda.com/engine-rest/external-task/test-task-id/failure",
+            status_code=204,
+        )
+
+        fail_task(self.task, "Everything is broken")
+
+        req = m.last_request
+        self.assertEqual(
+            req.json(),
+            {
+                "workerId": "test-worker-id",
+                "errorMessage": "Everything is broken",
+                "errorDetail": "Line 1\nLine 2",
+                "retries": 0,
+                "retryTimeout": 0,
+            },
+        )
+
+    def test_fail_without_explicit_reason(self, m):
+        m.post(
+            "https://some.camunda.com/engine-rest/external-task/test-task-id/failure",
+            status_code=204,
+        )
+
+        fail_task(self.task)
+
+        req = m.last_request
+        self.assertEqual(
+            req.json(),
+            {
+                "workerId": "test-worker-id",
+                "errorMessage": "Line 2",
+                "errorDetail": "Line 1\nLine 2",
+                "retries": 0,
+                "retryTimeout": 0,
+            },
+        )
+
+    def test_fail_without_traceback(self, m):
+        self.task.execution_error = ""
+        self.task.save()
+        m.post(
+            "https://some.camunda.com/engine-rest/external-task/test-task-id/failure",
+            status_code=204,
+        )
+
+        fail_task(self.task)
+
+        req = m.last_request
+        self.assertEqual(
+            req.json(),
+            {
+                "workerId": "test-worker-id",
+                "errorMessage": "",
+                "errorDetail": "",
+                "retries": 0,
+                "retryTimeout": 0,
+            },
+        )

--- a/src/bptl/camunda/utils.py
+++ b/src/bptl/camunda/utils.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 from dateutil import parser
-from django_camunda.client import get_client_class
+from django_camunda.client import get_client
 from django_camunda.types import JSONPrimitive
 
 from bptl.tasks.models import TaskMapping
@@ -26,7 +26,7 @@ def fetch_and_lock(max_tasks: int) -> Tuple[str, int, list]:
 
     API reference: https://docs.camunda.org/manual/7.12/reference/rest/external-task/fetch/
     """
-    camunda = get_client_class()()
+    camunda = get_client()
 
     # Fetch the topics that are known (and active!) in this configured instance only
     mappings = TaskMapping.objects.filter(active=True)
@@ -75,7 +75,7 @@ def complete_task(
     variables.
     """
     task_variables = task.get_variables()
-    camunda = get_client_class()()
+    camunda = get_client()
 
     serialized_variables = (
         {name: serialize_variable(value) for name, value in variables.items()}
@@ -133,4 +133,5 @@ def fail_task(task: ExternalTask, reason: str = "") -> None:
     """
     Mark an external task as failed.
     """
+
     raise Exception("foo")

--- a/src/bptl/camunda/utils.py
+++ b/src/bptl/camunda/utils.py
@@ -127,3 +127,10 @@ def deserialize_variable(variable: Dict[str, Any]) -> Any:
         return json.loads(variable["value"])
 
     raise NotImplementedError(f"Type {var_type} is not implemented yet")
+
+
+def fail_task(task: ExternalTask, reason: str = "") -> None:
+    """
+    Mark an external task as failed.
+    """
+    raise Exception("foo")


### PR DESCRIPTION
Currently the task is left as it is, expires, and the re-attempted. This results in a dashboard currently showing 524 failed tasks - all of which are essentially the same :-)

Errors during execution (!) are now translated in call to mark the external task in Camunda as a failure. We retain the error information, but also communicate details back to Camunda for debugging.