### PR TITLE
Implemented Camunda long polling

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,7 @@
 # Core python libraries
 Pillow  # handle images
 celery
+celery-once
 gemma-zds-client
 psycopg2  # database driver
 pytz  # handle timezones

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,8 @@ alabaster==0.7.12         # via sphinx
 amqp==2.5.2               # via kombu
 babel==2.8.0              # via flower, sphinx
 billiard==3.6.1.0         # via celery
-celery==4.4.0             # via -r requirements/base.in, django-camunda, flower
+celery-once==3.0.1        # via -r requirements/base.in
+celery==4.4.0             # via -r requirements/base.in, celery-once, django-camunda, flower
 certifi==2019.11.28       # via elastic-apm, requests, sentry-sdk
 cffi==1.13.2              # via cryptography
 chardet==3.0.4            # via requests
@@ -62,7 +63,7 @@ python-decouple==3.3      # via -r requirements/base.in
 python-dotenv==0.10.3     # via -r requirements/base.in
 pytz==2019.3              # via -r requirements/base.in, babel, celery, django, flower
 pyyaml==5.3               # via gemma-zds-client
-redis==3.3.11             # via django-redis
+redis==3.3.11             # via celery-once, django-redis
 requests==2.22.0          # via coreapi, django-auth-adfs, django-camunda, django-rosetta, gemma-zds-client, sphinx
 ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml==0.16.10      # via drf-yasg

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -9,7 +9,8 @@ amqp==2.5.2               # via -r requirements/base.txt, kombu
 babel==2.8.0              # via -r requirements/base.txt, flower, sphinx
 beautifulsoup4==4.8.2     # via webtest
 billiard==3.6.1.0         # via -r requirements/base.txt, celery
-celery==4.4.0             # via -r requirements/base.txt, django-camunda, flower
+celery-once==3.0.1        # via -r requirements/base.txt
+celery==4.4.0             # via -r requirements/base.txt, celery-once, django-camunda, flower
 certifi==2019.11.28       # via -r requirements/base.txt, elastic-apm, requests, sentry-sdk
 cffi==1.13.2              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
@@ -72,7 +73,7 @@ python-decouple==3.3      # via -r requirements/base.txt
 python-dotenv==0.10.3     # via -r requirements/base.txt
 pytz==2019.3              # via -r requirements/base.txt, babel, celery, django, flower
 pyyaml==5.3               # via -r requirements/base.txt, gemma-zds-client
-redis==3.3.11             # via -r requirements/base.txt, django-redis
+redis==3.3.11             # via -r requirements/base.txt, celery-once, django-redis
 requests-mock==1.7.0      # via -r requirements/test-tools.in
 requests==2.22.0          # via -r requirements/base.txt, coreapi, django-auth-adfs, django-camunda, django-rosetta, gemma-zds-client, requests-mock, sphinx
 ruamel.yaml.clib==0.2.0   # via -r requirements/base.txt, ruamel.yaml

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,7 +13,8 @@ beautifulsoup4==4.8.2     # via -r requirements/ci.txt, webtest
 billiard==3.6.1.0         # via -r requirements/ci.txt, celery
 black==19.10b0            # via -r requirements/dev.in
 bumpversion==0.5.3        # via -r requirements/dev.in
-celery==4.4.0             # via -r requirements/ci.txt, django-camunda, flower
+celery-once==3.0.1        # via -r requirements/ci.txt
+celery==4.4.0             # via -r requirements/ci.txt, celery-once, django-camunda, flower
 certifi==2019.11.28       # via -r requirements/ci.txt, elastic-apm, requests, sentry-sdk
 cffi==1.13.2              # via -r requirements/ci.txt, cryptography
 chardet==3.0.4            # via -r requirements/ci.txt, requests
@@ -87,7 +88,7 @@ python-decouple==3.3      # via -r requirements/ci.txt
 python-dotenv==0.10.3     # via -r requirements/ci.txt
 pytz==2019.3              # via -r requirements/ci.txt, babel, celery, django, flower
 pyyaml==5.3               # via -r requirements/ci.txt, gemma-zds-client
-redis==3.3.11             # via -r requirements/ci.txt, django-redis
+redis==3.3.11             # via -r requirements/ci.txt, celery-once, django-redis
 regex==2020.1.8           # via black
 requests-mock==1.7.0      # via -r requirements/ci.txt
 requests==2.22.0          # via -r requirements/ci.txt, coreapi, django-auth-adfs, django-camunda, django-rosetta, gemma-zds-client, requests-mock, sphinx

--- a/src/bptl/camunda/tasks.py
+++ b/src/bptl/camunda/tasks.py
@@ -2,6 +2,7 @@
 from django.conf import settings
 
 from celery.utils.log import get_task_logger
+from celery_once import QueueOnce
 from timeline_logger.models import TimelineLog
 
 from bptl.camunda.api import complete
@@ -18,9 +19,23 @@ logger = get_task_logger(__name__)
 __all__ = ("task_fetch_and_lock", "task_execute_and_complete")
 
 
-@app.task()
+@app.task(
+    base=QueueOnce,
+    autoretry_for=(Exception,),  # if something goes wrong, automatically retry the task
+    retry_backoff=True,
+    once={
+        "graceful": True,  # raise no exception if we're scheduling this more often (beat!)
+        "timeout": (
+            settings.LONG_POLLING_TIMEOUT_MINUTES * 60 + 1
+        ),  # timeout if something goes wrong
+    },
+)
 def task_fetch_and_lock():
-    worker_id, num_tasks, tasks = fetch_and_lock(settings.MAX_TASKS)
+    worker_id, num_tasks, tasks = fetch_and_lock(
+        settings.MAX_TASKS,
+        # convert to milliseconds
+        long_polling_timeout=settings.LONG_POLLING_TIMEOUT_MINUTES * 60 * 1000,
+    )
 
     logger.info("fetched %r tasks with %r", num_tasks, worker_id)
 
@@ -31,6 +46,11 @@ def task_fetch_and_lock():
         )
 
         task_execute_and_complete.delay(task.id)
+
+    # once we're completed, which may be way within the timeout, we need to-reschedule
+    # a new long-poll!
+    task_fetch_and_lock.delay()
+
     return num_tasks
 
 

--- a/src/bptl/camunda/utils.py
+++ b/src/bptl/camunda/utils.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 LOCK_DURATION = 60 * 10  # 10 minutes
 
 
-def fetch_and_lock(max_tasks: int) -> Tuple[str, int, list]:
+def fetch_and_lock(max_tasks: int, long_polling_timeout=None) -> Tuple[str, int, list]:
     """
     Fetch and lock a number of external tasks.
 
@@ -39,10 +39,16 @@ def fetch_and_lock(max_tasks: int) -> Tuple[str, int, list]:
     ]
 
     worker_id = get_worker_id()
+    body = {
+        "workerId": worker_id,
+        "maxTasks": max_tasks,
+        "topics": topics,
+    }
+    if long_polling_timeout:
+        body["asyncResponseTimeout"] = long_polling_timeout
+
     external_tasks: List[Object] = camunda.request(
-        "external-task/fetchAndLock",
-        method="POST",
-        json={"workerId": worker_id, "maxTasks": max_tasks, "topics": topics,},
+        "external-task/fetchAndLock", method="POST", json=body
     )
 
     fetched = []


### PR DESCRIPTION
Added celery-once to prevent multiple workers from opening long-poll
connections to Camunda.

When the task exits (both succesfully or on exception), it re-schedules
itself to open a new connection as soon as possible. In the event that
this would fail, beat also makes sure to try to fetch and lock tasks
every 10 seconds, which is fine because of celery-once managing a
shared lock.

Currently, the long-poll connection is kept open for a maximum of 10min,
if all is well, we can increase this to the maximum of 30 minutes.

The end result is that tasks should be picked up pretty much as they
are scheduled in Camunda, leading to a more fluent user-experience.