### PR TITLE
Ensure child/worker processes receive SIGTERM

### DIFF
--- a/bin/celery_beat.sh
+++ b/bin/celery_beat.sh
@@ -7,7 +7,7 @@ LOGLEVEL=${CELERY_LOGLEVEL:-INFO}
 mkdir -p celerybeat
 
 echo "Starting celery beat"
-celery beat \
+exec celery beat \
     --app bptl \
     -l $LOGLEVEL \
     --workdir src \

--- a/bin/celery_flower.sh
+++ b/bin/celery_flower.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-celery flower --app bptl --workdir src
+exec celery flower --app bptl --workdir src

--- a/bin/celery_worker.sh
+++ b/bin/celery_worker.sh
@@ -9,7 +9,7 @@ QUEUE=${1:-${CELERY_WORKER_QUEUE:=celery}}
 WORKER_NAME=${2:-${CELERY_WORKER_NAME:="${QUEUE}"@%n}}
 
 echo "Starting celery worker $WORKER_NAME with queue $QUEUE"
-celery worker \
+exec celery worker \
     --app bptl \
     -Q $QUEUE \
     -n $WORKER_NAME \

--- a/bin/docker_start.sh
+++ b/bin/docker_start.sh
@@ -26,7 +26,7 @@ python src/manage.py migrate
 
 # Start server
 >&2 echo "Starting server"
-uwsgi \
+exec uwsgi \
     --http :$uwsgi_port \
     --http-keepalive \
     --module bptl.wsgi \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     # NOTE: No persistance storage configured.
     # See: https://hub.docker.com/_/postgres/
     image: postgres:12
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
     # NOTE: this works for bitnami, not sure if this works for regular
     # postgres image
     volumes:


### PR DESCRIPTION
This wasn't the case before because child processes were spawned and
bash does not propagate the signals.

Especially with large grace times, having warm shutdown on workers work
correctly should keep zero-downtime deployments in kubernetes as fast
as possible.