### PR TITLE
Add support for setting Kownsl metadata

### DIFF
--- a/src/bptl/work_units/kownsl/tasks.py
+++ b/src/bptl/work_units/kownsl/tasks.py
@@ -230,6 +230,7 @@ def get_email_details(task: BaseTask) -> dict:
     **Sets the process variables**
 
     * ``email``: a JSON that holds the email content and subject.
+
       .. code-block:: json
 
             {
@@ -238,6 +239,7 @@ def get_email_details(task: BaseTask) -> dict:
             }
 
     * ``context``: a JSON that holds data relevant to the email:
+
       .. code-block:: json
 
             {
@@ -248,7 +250,7 @@ def get_email_details(task: BaseTask) -> dict:
 
     * ``template``: a string that determines which template will be used for the email.
     * ``senderUsername``: a list that holds a string of the review requester's username.
-    This is used to determine the email's sender's details.
+      This is used to determine the email's sender's details.
     """
     # Get review request
     review_request = get_review_request(task)
@@ -293,3 +295,40 @@ def get_email_details(task: BaseTask) -> dict:
         "template": template,
         "senderUsername": [requester],
     }
+
+
+@register
+def set_review_request_metadata(task: BaseTask) -> dict:
+    """
+    Set the metadata for a Kownsl review request.
+
+    Metadata is a set of arbitrary key-value labels, allowing you to attach extra data
+    required for your process routing/handling.
+
+    **Required process variables**
+
+    * ``kownslReviewRequestId``: the identifier of the Kownsl review request.
+    * ``metadata``: a JSON structure holding key-values of the metadata. This will be
+      set directly on the matching review request. Example:
+
+      .. code-block:: json
+
+            {
+                "processInstanceId": "aProcessInstanceId"
+            }
+
+    **Sets no process variables**
+
+    """
+    variables = task.get_variables()
+    review_request_id = check_variable(variables, "kownslReviewRequestId")
+    metadata = check_variable(variables, "metadata")
+
+    client = get_client(task)
+    client.partial_update(
+        "reviewrequest",
+        data={"metadata": metadata},
+        uuid=review_request_id,
+    )
+
+    return {}

--- a/src/bptl/work_units/kownsl/tasks.py
+++ b/src/bptl/work_units/kownsl/tasks.py
@@ -44,48 +44,6 @@ def get_review_request(task: BaseTask) -> dict:
 
 
 @register
-def finalize_review_request(task: BaseTask) -> dict:
-    """
-    Update a review request in Kownsl.
-
-    DEPRECATED - do not use anymore.
-
-    Review requests can be requests for advice or approval. This tasks registers the
-    case used for the actual review with the review request, and derives the frontend
-    URL for end-users where they can submit their review.
-
-    In the task binding, the service with alias ``kownsl`` must be connected, so that
-    this task knows which endpoints to contact.
-
-    **Required process variables**
-
-    * ``reviewRequestId``: the identifier of the Kownsl review request.
-    * ``zaakUrl``: URL reference to the zaak used for the review itself.
-
-    **Sets the process variables**
-
-    * ``doReviewUrl``: the frontend URL that reviewers visit to submit the review
-
-    """
-    variables = task.get_variables()
-
-    request_id = check_variable(variables, "reviewRequestId")
-    zaak_url = check_variable(variables, "zaakUrl")
-
-    client = get_client(task)
-
-    resp_data = client.partial_update(
-        "reviewrequest",
-        data={"review_zaak": zaak_url},
-        uuid=request_id,
-    )
-
-    return {
-        "doReviewUrl": resp_data["frontend_url"],
-    }
-
-
-@register
 def get_approval_status(task: BaseTask) -> dict:
     """
     Get the result of an approval review request.

--- a/src/bptl/work_units/kownsl/tests/schemas/kownsl.yaml
+++ b/src/bptl/work_units/kownsl/tests/schemas/kownsl.yaml
@@ -51,6 +51,11 @@ paths:
                       enum:
                       - advice
                       - approval
+                    documents:
+                      type: array
+                      items:
+                        type: string
+                        format: uri
                     frontend_url:
                       type: string
                       readOnly: true
@@ -70,6 +75,17 @@ paths:
                       type: integer
                       maximum: 32767
                       minimum: 0
+                    toelichting:
+                      type: string
+                    user_deadlines:
+                      type: object
+                    requester:
+                      type: string
+                      description: Username of user who requested review request
+                      maxLength: 100
+                    metadata:
+                      type: object
+                      description: Metadata that may be relevant for the process.
                   required:
                   - for_zaak
                   - review_type
@@ -101,10 +117,26 @@ paths:
                   enum:
                   - advice
                   - approval
+                documents:
+                  type: array
+                  items:
+                    type: string
+                    format: uri
                 num_assigned_users:
                   type: integer
                   maximum: 32767
                   minimum: 0
+                toelichting:
+                  type: string
+                user_deadlines:
+                  type: object
+                requester:
+                  type: string
+                  description: Username of user who requested review request
+                  maxLength: 100
+                metadata:
+                  type: object
+                  description: Metadata that may be relevant for the process.
               required:
               - for_zaak
               - review_type
@@ -137,6 +169,11 @@ paths:
                     enum:
                     - advice
                     - approval
+                  documents:
+                    type: array
+                    items:
+                      type: string
+                      format: uri
                   frontend_url:
                     type: string
                     readOnly: true
@@ -155,9 +192,380 @@ paths:
                     type: integer
                     maximum: 32767
                     minimum: 0
+                  toelichting:
+                    type: string
+                  user_deadlines:
+                    type: object
+                  requester:
+                    type: string
+                    description: Username of user who requested review request
+                    maxLength: 100
+                  metadata:
+                    type: object
+                    description: Metadata that may be relevant for the process.
                 required:
                 - for_zaak
                 - review_type
+          description: ''
+  /api/v1/review-requests/{uuid}:
+    get:
+      operationId: reviewrequest_retrieve
+      description: 'CRUD operations on review requests.
+
+
+        Note that the list endpoint _requires_ a filter parameter.'
+      parameters:
+      - name: uuid
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: for_zaak
+        required: false
+        in: query
+        description: for_zaak
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                    readOnly: true
+                  for_zaak:
+                    type: string
+                    format: uri
+                    description: URL reference to the zaak in the API.
+                    maxLength: 1000
+                    pattern: "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\\
+                      d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\\
+                      [[0-9a-f:\\.]+\\]|([a-z\xA1-\uFFFF0-9](?:[a-z\xA1-\uFFFF0-9-]{0,61}[a-z\xA1\
+                      -\uFFFF0-9])?(?:\\.(?!-)[a-z\xA1-\uFFFF0-9-]{1,63}(?<!-))*\\\
+                      .(?!-)(?:[a-z\xA1-\uFFFF-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\\
+                      .?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
+                  review_type:
+                    enum:
+                    - advice
+                    - approval
+                  documents:
+                    type: array
+                    items:
+                      type: string
+                      format: uri
+                  frontend_url:
+                    type: string
+                    readOnly: true
+                    description: The frontend URL for reviewers to submit their review.
+                  num_advices:
+                    type: integer
+                    readOnly: true
+                    description: The number of advices registered for this request.
+                  num_approvals:
+                    type: integer
+                    readOnly: true
+                    description: The number of approvals registered for this request.
+                      Note that does not mean they are all positive approvals - this
+                      includes the rejections.
+                  num_assigned_users:
+                    type: integer
+                    maximum: 32767
+                    minimum: 0
+                  toelichting:
+                    type: string
+                  user_deadlines:
+                    type: object
+                  requester:
+                    type: string
+                    description: Username of user who requested review request
+                    maxLength: 100
+                  metadata:
+                    type: object
+                    description: Metadata that may be relevant for the process.
+                required:
+                - for_zaak
+                - review_type
+          description: ''
+    put:
+      operationId: reviewrequest_update
+      description: 'CRUD operations on review requests.
+
+
+        Note that the list endpoint _requires_ a filter parameter.'
+      parameters:
+      - name: uuid
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: for_zaak
+        required: false
+        in: query
+        description: for_zaak
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema: &id002
+              properties:
+                for_zaak:
+                  type: string
+                  format: uri
+                  description: URL reference to the zaak in the API.
+                  maxLength: 1000
+                  pattern: "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\\
+                    d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\\
+                    [[0-9a-f:\\.]+\\]|([a-z\xA1-\uFFFF0-9](?:[a-z\xA1-\uFFFF0-9-]{0,61}[a-z\xA1\
+                    -\uFFFF0-9])?(?:\\.(?!-)[a-z\xA1-\uFFFF0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\xA1\
+                    -\uFFFF-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\\
+                    d{2,5})?(?:[/?#][^\\s]*)?\\Z"
+                review_type:
+                  enum:
+                  - advice
+                  - approval
+                documents:
+                  type: array
+                  items:
+                    type: string
+                    format: uri
+                num_assigned_users:
+                  type: integer
+                  maximum: 32767
+                  minimum: 0
+                toelichting:
+                  type: string
+                user_deadlines:
+                  type: object
+                requester:
+                  type: string
+                  description: Username of user who requested review request
+                  maxLength: 100
+                metadata:
+                  type: object
+                  description: Metadata that may be relevant for the process.
+              required:
+              - for_zaak
+              - review_type
+          application/x-www-form-urlencoded:
+            schema: *id002
+          multipart/form-data:
+            schema: *id002
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                    readOnly: true
+                  for_zaak:
+                    type: string
+                    format: uri
+                    description: URL reference to the zaak in the API.
+                    maxLength: 1000
+                    pattern: "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\\
+                      d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\\
+                      [[0-9a-f:\\.]+\\]|([a-z\xA1-\uFFFF0-9](?:[a-z\xA1-\uFFFF0-9-]{0,61}[a-z\xA1\
+                      -\uFFFF0-9])?(?:\\.(?!-)[a-z\xA1-\uFFFF0-9-]{1,63}(?<!-))*\\\
+                      .(?!-)(?:[a-z\xA1-\uFFFF-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\\
+                      .?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
+                  review_type:
+                    enum:
+                    - advice
+                    - approval
+                  documents:
+                    type: array
+                    items:
+                      type: string
+                      format: uri
+                  frontend_url:
+                    type: string
+                    readOnly: true
+                    description: The frontend URL for reviewers to submit their review.
+                  num_advices:
+                    type: integer
+                    readOnly: true
+                    description: The number of advices registered for this request.
+                  num_approvals:
+                    type: integer
+                    readOnly: true
+                    description: The number of approvals registered for this request.
+                      Note that does not mean they are all positive approvals - this
+                      includes the rejections.
+                  num_assigned_users:
+                    type: integer
+                    maximum: 32767
+                    minimum: 0
+                  toelichting:
+                    type: string
+                  user_deadlines:
+                    type: object
+                  requester:
+                    type: string
+                    description: Username of user who requested review request
+                    maxLength: 100
+                  metadata:
+                    type: object
+                    description: Metadata that may be relevant for the process.
+                required:
+                - for_zaak
+                - review_type
+          description: ''
+    patch:
+      operationId: reviewrequest_partial_update
+      description: 'CRUD operations on review requests.
+
+
+        Note that the list endpoint _requires_ a filter parameter.'
+      parameters:
+      - name: uuid
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: for_zaak
+        required: false
+        in: query
+        description: for_zaak
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema: &id003
+              properties:
+                for_zaak:
+                  type: string
+                  format: uri
+                  description: URL reference to the zaak in the API.
+                  maxLength: 1000
+                  pattern: "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\\
+                    d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\\
+                    [[0-9a-f:\\.]+\\]|([a-z\xA1-\uFFFF0-9](?:[a-z\xA1-\uFFFF0-9-]{0,61}[a-z\xA1\
+                    -\uFFFF0-9])?(?:\\.(?!-)[a-z\xA1-\uFFFF0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\xA1\
+                    -\uFFFF-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\\
+                    d{2,5})?(?:[/?#][^\\s]*)?\\Z"
+                review_type:
+                  enum:
+                  - advice
+                  - approval
+                documents:
+                  type: array
+                  items:
+                    type: string
+                    format: uri
+                num_assigned_users:
+                  type: integer
+                  maximum: 32767
+                  minimum: 0
+                toelichting:
+                  type: string
+                user_deadlines:
+                  type: object
+                requester:
+                  type: string
+                  description: Username of user who requested review request
+                  maxLength: 100
+                metadata:
+                  type: object
+                  description: Metadata that may be relevant for the process.
+          application/x-www-form-urlencoded:
+            schema: *id003
+          multipart/form-data:
+            schema: *id003
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                    readOnly: true
+                  for_zaak:
+                    type: string
+                    format: uri
+                    description: URL reference to the zaak in the API.
+                    maxLength: 1000
+                    pattern: "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\\
+                      d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\\
+                      [[0-9a-f:\\.]+\\]|([a-z\xA1-\uFFFF0-9](?:[a-z\xA1-\uFFFF0-9-]{0,61}[a-z\xA1\
+                      -\uFFFF0-9])?(?:\\.(?!-)[a-z\xA1-\uFFFF0-9-]{1,63}(?<!-))*\\\
+                      .(?!-)(?:[a-z\xA1-\uFFFF-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\\
+                      .?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
+                  review_type:
+                    enum:
+                    - advice
+                    - approval
+                  documents:
+                    type: array
+                    items:
+                      type: string
+                      format: uri
+                  frontend_url:
+                    type: string
+                    readOnly: true
+                    description: The frontend URL for reviewers to submit their review.
+                  num_advices:
+                    type: integer
+                    readOnly: true
+                    description: The number of advices registered for this request.
+                  num_approvals:
+                    type: integer
+                    readOnly: true
+                    description: The number of approvals registered for this request.
+                      Note that does not mean they are all positive approvals - this
+                      includes the rejections.
+                  num_assigned_users:
+                    type: integer
+                    maximum: 32767
+                    minimum: 0
+                  toelichting:
+                    type: string
+                  user_deadlines:
+                    type: object
+                  requester:
+                    type: string
+                    description: Username of user who requested review request
+                    maxLength: 100
+                  metadata:
+                    type: object
+                    description: Metadata that may be relevant for the process.
+                required:
+                - for_zaak
+                - review_type
+          description: ''
+    delete:
+      operationId: reviewrequest_destroy
+      description: 'CRUD operations on review requests.
+
+
+        Note that the list endpoint _requires_ a filter parameter.'
+      parameters:
+      - name: uuid
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: for_zaak
+        required: false
+        in: query
+        description: for_zaak
+        schema:
+          type: string
+      responses:
+        '204':
           description: ''
   /api/v1/review-requests/{uuid}/advices:
     get:
@@ -280,200 +688,11 @@ paths:
                     approved:
                       type: boolean
                       description: Vink dit aan om akkoord te gaan met het/de document(en).
+                    toelichting:
+                      type: string
+                      description: Voeg een toelichting toe aan de accordering.
                   required:
                   - author
-          description: ''
-  /api/v1/review-requests/{uuid}:
-    put:
-      operationId: reviewrequest_update
-      description: 'CRUD operations on review requests.
-
-
-        Note that the list endpoint _requires_ a filter parameter.'
-      parameters:
-      - name: uuid
-        in: path
-        required: true
-        description: ''
-        schema:
-          type: string
-      - name: for_zaak
-        required: false
-        in: query
-        description: for_zaak
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema: &id002
-              properties:
-                for_zaak:
-                  type: string
-                  format: uri
-                  description: URL reference to the zaak in the API.
-                  maxLength: 1000
-                  pattern: "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\\
-                    d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\\
-                    [[0-9a-f:\\.]+\\]|([a-z\xA1-\uFFFF0-9](?:[a-z\xA1-\uFFFF0-9-]{0,61}[a-z\xA1\
-                    -\uFFFF0-9])?(?:\\.(?!-)[a-z\xA1-\uFFFF0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\xA1\
-                    -\uFFFF-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\\
-                    d{2,5})?(?:[/?#][^\\s]*)?\\Z"
-                review_type:
-                  enum:
-                  - advice
-                  - approval
-                num_assigned_users:
-                  type: integer
-                  maximum: 32767
-                  minimum: 0
-              required:
-              - for_zaak
-              - review_type
-          application/x-www-form-urlencoded:
-            schema: *id002
-          multipart/form-data:
-            schema: *id002
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  id:
-                    type: string
-                    format: uuid
-                    readOnly: true
-                  for_zaak:
-                    type: string
-                    format: uri
-                    description: URL reference to the zaak in the API.
-                    maxLength: 1000
-                    pattern: "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\\
-                      d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\\
-                      [[0-9a-f:\\.]+\\]|([a-z\xA1-\uFFFF0-9](?:[a-z\xA1-\uFFFF0-9-]{0,61}[a-z\xA1\
-                      -\uFFFF0-9])?(?:\\.(?!-)[a-z\xA1-\uFFFF0-9-]{1,63}(?<!-))*\\\
-                      .(?!-)(?:[a-z\xA1-\uFFFF-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\\
-                      .?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
-                  review_type:
-                    enum:
-                    - advice
-                    - approval
-                  frontend_url:
-                    type: string
-                    readOnly: true
-                    description: The frontend URL for reviewers to submit their review.
-                  num_advices:
-                    type: integer
-                    readOnly: true
-                    description: The number of advices registered for this request.
-                  num_approvals:
-                    type: integer
-                    readOnly: true
-                    description: The number of approvals registered for this request.
-                      Note that does not mean they are all positive approvals - this
-                      includes the rejections.
-                  num_assigned_users:
-                    type: integer
-                    maximum: 32767
-                    minimum: 0
-                required:
-                - for_zaak
-                - review_type
-          description: ''
-    patch:
-      operationId: reviewrequest_partial_update
-      description: 'CRUD operations on review requests.
-
-
-        Note that the list endpoint _requires_ a filter parameter.'
-      parameters:
-      - name: uuid
-        in: path
-        required: true
-        description: ''
-        schema:
-          type: string
-      - name: for_zaak
-        required: false
-        in: query
-        description: for_zaak
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema: &id003
-              properties:
-                for_zaak:
-                  type: string
-                  format: uri
-                  description: URL reference to the zaak in the API.
-                  maxLength: 1000
-                  pattern: "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\\
-                    d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\\
-                    [[0-9a-f:\\.]+\\]|([a-z\xA1-\uFFFF0-9](?:[a-z\xA1-\uFFFF0-9-]{0,61}[a-z\xA1\
-                    -\uFFFF0-9])?(?:\\.(?!-)[a-z\xA1-\uFFFF0-9-]{1,63}(?<!-))*\\.(?!-)(?:[a-z\xA1\
-                    -\uFFFF-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\.?|localhost))(?::\\\
-                    d{2,5})?(?:[/?#][^\\s]*)?\\Z"
-                review_type:
-                  enum:
-                  - advice
-                  - approval
-                num_assigned_users:
-                  type: integer
-                  maximum: 32767
-                  minimum: 0
-          application/x-www-form-urlencoded:
-            schema: *id003
-          multipart/form-data:
-            schema: *id003
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  id:
-                    type: string
-                    format: uuid
-                    readOnly: true
-                  for_zaak:
-                    type: string
-                    format: uri
-                    description: URL reference to the zaak in the API.
-                    maxLength: 1000
-                    pattern: "^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:(?:25[0-5]|2[0-4]\\\
-                      d|[0-1]?\\d?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}|\\\
-                      [[0-9a-f:\\.]+\\]|([a-z\xA1-\uFFFF0-9](?:[a-z\xA1-\uFFFF0-9-]{0,61}[a-z\xA1\
-                      -\uFFFF0-9])?(?:\\.(?!-)[a-z\xA1-\uFFFF0-9-]{1,63}(?<!-))*\\\
-                      .(?!-)(?:[a-z\xA1-\uFFFF-]{2,63}|xn--[a-z0-9]{1,59})(?<!-)\\\
-                      .?|localhost))(?::\\d{2,5})?(?:[/?#][^\\s]*)?\\Z"
-                  review_type:
-                    enum:
-                    - advice
-                    - approval
-                  frontend_url:
-                    type: string
-                    readOnly: true
-                    description: The frontend URL for reviewers to submit their review.
-                  num_advices:
-                    type: integer
-                    readOnly: true
-                    description: The number of advices registered for this request.
-                  num_approvals:
-                    type: integer
-                    readOnly: true
-                    description: The number of approvals registered for this request.
-                      Note that does not mean they are all positive approvals - this
-                      includes the rejections.
-                  num_assigned_users:
-                    type: integer
-                    maximum: 32767
-                    minimum: 0
-                required:
-                - for_zaak
-                - review_type
           description: ''
 servers:
 - url: https://kownsl.utrechtproeftuin.nl


### PR DESCRIPTION
This is required in our processes for when:

* user arrives at Kownsl page from e-mail
* Kownsl sends notification of review
* ZAC listens to notification
* ZAC fetches meta-information from Kownsl to be able to close the Camunda user task

This functionality allows us to update the meta-information that ZAC needs, from the process with an automated service task.