### PR TITLE
Added a task that will retrieve approval toelichtingen for a review r…

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -45,7 +45,7 @@ docutils==0.16            # via django-docutils, sphinx
 drf-yasg==1.17.1          # via -r requirements/base.in
 elastic-apm==5.3.2        # via -r requirements/base.in
 flower==0.9.3             # via -r requirements/base.in
-gemma-zds-client==0.13.2  # via -r requirements/base.in, zgw-consumers
+gemma-zds-client==0.13.4  # via -r requirements/base.in, zgw-consumers
 idna==2.8                 # via requests
 imagesize==1.2.0          # via sphinx
 inflection==0.3.1         # via django-camunda, drf-yasg

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -53,7 +53,7 @@ factory-boy==2.12.0       # via -r requirements/test-tools.in
 faker==3.0.0              # via factory-boy
 flower==0.9.3             # via -r requirements/base.txt
 freezegun==0.3.12         # via -r requirements/test-tools.in
-gemma-zds-client==0.13.2  # via -r requirements/base.txt, zgw-consumers
+gemma-zds-client==0.13.4  # via -r requirements/base.txt, zgw-consumers
 idna==2.8                 # via -r requirements/base.txt, requests
 imagesize==1.2.0          # via -r requirements/base.txt, sphinx
 inflection==0.3.1         # via -r requirements/base.txt, django-camunda, drf-yasg

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -61,7 +61,7 @@ faker==3.0.0              # via -r requirements/ci.txt, factory-boy
 flake8==3.7.9             # via -r requirements/dev.in
 flower==0.9.3             # via -r requirements/ci.txt
 freezegun==0.3.12         # via -r requirements/ci.txt
-gemma-zds-client==0.13.2  # via -r requirements/ci.txt, zgw-consumers
+gemma-zds-client==0.13.4  # via -r requirements/ci.txt, zgw-consumers
 idna==2.8                 # via -r requirements/ci.txt, requests
 imagesize==1.2.0          # via -r requirements/ci.txt, sphinx
 inflection==0.3.1         # via -r requirements/ci.txt, django-camunda, drf-yasg

--- a/src/bptl/work_units/kownsl/utils.py
+++ b/src/bptl/work_units/kownsl/utils.py
@@ -1,3 +1,4 @@
+from zds_client.schema import get_operation_url
 from zgw_consumers.client import ZGWClient
 
 from bptl.tasks.base import BaseTask, MissingVariable, check_variable
@@ -22,18 +23,19 @@ def get_review_request(task: BaseTask) -> dict:
     """
     Get a single review request from kownsl.
     """
+
+    # Get variables
     variables = task.get_variables()
 
-    zaak_url = check_variable(variables, "zaakUrl")
+    # Build url
     client = get_client(task)
-    resp_data = client.list(
-        "reviewrequest",
-        query_params={"for_zaak": zaak_url},
+    review_request_id = check_variable(variables, "kownslReviewRequestId")
+    operation_id = "reviewrequest_retrieve"
+    url = get_operation_url(
+        client.schema,
+        operation_id,
+        base_url=client.base_url,
+        uuid=review_request_id,
     )
-
-    request_id = check_variable(variables, "kownslReviewRequestId")
-    for review_request in resp_data:
-        if review_request["id"] == request_id:
-            return review_request
-
-    raise MissingVariable(f"Review request: {request_id} not found.")
+    review_requests = client.request(url, operation_id)
+    return review_requests[0]

--- a/src/bptl/work_units/kownsl/utils.py
+++ b/src/bptl/work_units/kownsl/utils.py
@@ -1,0 +1,39 @@
+from zgw_consumers.client import ZGWClient
+
+from bptl.tasks.base import BaseTask, MissingVariable, check_variable
+from bptl.tasks.models import TaskMapping
+
+
+def get_client(task: BaseTask, alias: str = "kownsl") -> ZGWClient:
+    default_services = TaskMapping.objects.get(
+        topic_name=task.topic_name
+    ).defaultservice_set.select_related("service")
+    services_by_alias = {svc.alias: svc.service for svc in default_services}
+    if alias not in services_by_alias:
+        raise RuntimeError(f"Service alias '{alias}' not found.")
+
+    client = services_by_alias[alias].build_client()
+    client._log.task = task
+
+    return client
+
+
+def get_review_request(task: BaseTask) -> dict:
+    """
+    Get a single review request from kownsl.
+    """
+    variables = task.get_variables()
+
+    zaak_url = check_variable(variables, "zaakUrl")
+    client = get_client(task)
+    resp_data = client.list(
+        "reviewrequest",
+        query_params={"for_zaak": zaak_url},
+    )
+
+    request_id = check_variable(variables, "kownslReviewRequestId")
+    for review_request in resp_data:
+        if review_request["id"] == request_id:
+            return review_request
+
+    raise MissingVariable(f"Review request: {request_id} not found.")

--- a/src/bptl/work_units/zgw/log.py
+++ b/src/bptl/work_units/zgw/log.py
@@ -16,7 +16,6 @@ class DBLog:
         response_data: dict,
         params: dict = None,
     ):
-
         extra_data = {
             "service_base_url": service,
             "request": {
@@ -32,4 +31,5 @@ class DBLog:
                 "data": response_data,
             },
         }
+
         TimelineLog.objects.create(content_object=self.task, extra_data=extra_data)

--- a/src/bptl/work_units/zgw/log.py
+++ b/src/bptl/work_units/zgw/log.py
@@ -31,5 +31,4 @@ class DBLog:
                 "data": response_data,
             },
         }
-
         TimelineLog.objects.create(content_object=self.task, extra_data=extra_data)

--- a/src/bptl/work_units/zgw/log.py
+++ b/src/bptl/work_units/zgw/log.py
@@ -16,6 +16,7 @@ class DBLog:
         response_data: dict,
         params: dict = None,
     ):
+        
         extra_data = {
             "service_base_url": service,
             "request": {


### PR DESCRIPTION
…equest.

Context:
@MichelleDautzenberg asked if we could retrieve the "toelichtingen" for approval reviews so that we can include them in an email to be sent somewhere after a reviewee doesn't approve.

Fixes: GemeenteUtrecht/ZGW/issues/620