### PR TITLE
Fixes GemeenteUtrecht/ZGW#628 -- allow empty rol-omschrijving

### DIFF
--- a/src/bptl/work_units/zgw/tests/test_task_create_rol.py
+++ b/src/bptl/work_units/zgw/tests/test_task_create_rol.py
@@ -108,3 +108,12 @@ class CreateRolTaskTests(TestCase):
                 "betrokkeneIdentificatie": {},
             },
         )
+
+    def test_no_create_rol_empty_omschrijving(self, m):
+        self.fetched_task.variables["omschrijving"] = serialize_variable("")
+        task = CreateRolTask(self.fetched_task)
+
+        result = task.perform()
+
+        self.assertIsNone(result)
+        self.assertEqual(len(m.request_history), 0)


### PR DESCRIPTION
Allowing the empty variable, and dealing with it by bypassing all
business logic adds more flexibility for process designers.