### PR TITLE
Fixes #116 - Display Xential templates in admin

### DIFF
--- a/src/bptl/templates/admin/xential/templates.html
+++ b/src/bptl/templates/admin/xential/templates.html
@@ -13,20 +13,20 @@
 {% block content %}
 <div id="content-main">
     <div class="module">
-        {% for api_root, templates in template_groups.items %}
-            <h2>{{ api_root }}</h2>
+        {% for template_group in template_groups %}
+            <h2>Template Group {{ template_group.name }}</h2>
             <table style="width:100%">
                 <thead>
                     <tr>
-                        <th>{% trans 'Name' %}</th>
-                        <th>Uuid</th>
+                        <th>{% trans 'Template name' %}</th>
+                        <th>{% trans 'UUID' %}</th>
                     </tr>
                 </thead>
                 <tbody>
-                {% for template in templates %}
+                {% for template in template_group.templates %}
                     <tr>
-                        <td>{{ template.templateName }}</td>
-                        <td>{{ template.templateUuid }}</td>
+                        <td>{{ template.name }}</td>
+                        <td>{{ template.uuid }}</td>
                     </tr>
                 {% endfor %}
                 </tbody>

--- a/src/bptl/templates/admin/xential/templates.html
+++ b/src/bptl/templates/admin/xential/templates.html
@@ -14,7 +14,12 @@
 <div id="content-main">
     <div class="module">
         {% for template_group in template_groups %}
-            <h2>Template Group {{ template_group.name }}</h2>
+            <h2
+                title="This template group comes from the api {{ template_group.api }}"
+                style="cursor: help"
+            >
+                Template Group {{ template_group.name }}
+            </h2>
             <table style="width:100%">
                 <thead>
                     <tr>

--- a/src/bptl/work_units/xential/admin_views.py
+++ b/src/bptl/work_units/xential/admin_views.py
@@ -2,7 +2,7 @@ from django.views.generic import TemplateView
 
 from bptl.utils.admin import StaffRequiredMixin
 
-from .client import get_default_clients
+from .client import get_xential_client
 
 
 class TemplatesListView(StaffRequiredMixin, TemplateView):
@@ -12,13 +12,34 @@ class TemplatesListView(StaffRequiredMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        template_groups = {}
-        list_url = "xential/templates"
-        xential_clients = get_default_clients()
-        for client in xential_clients:
-            list_response = client.get(list_url)
-            template_groups[client.api_root] = list_response["data"]["templates"]
+        template_groups = []
+        template_groups_url = "template_utils/getUsableTemplates"
+        xential_client = get_xential_client()
+
+        template_groups_details = xential_client.post(template_groups_url)
+        for template_group in template_groups_details["objects"]:
+            template_group_name = get_name(template_group["fields"])
+            template_group_context = {"name": f"{template_group_name}", "templates": []}
+
+            templates_details = xential_client.post(
+                template_groups_url, params={"parentGroupUuid": template_group["uuid"]}
+            )
+            for template in templates_details["objects"]:
+                template_name = get_name(template["fields"])
+                template_group_context["templates"].append(
+                    {"name": template_name, "uuid": template["uuid"]}
+                )
+
+            template_groups.append(template_group_context)
 
         context.update({"template_groups": template_groups})
 
         return context
+
+
+def get_name(fields: dict) -> str:
+    for field in fields:
+        if field["name"] == "name":
+            return field["value"]
+
+    return "Geen naam"

--- a/src/bptl/work_units/xential/admin_views.py
+++ b/src/bptl/work_units/xential/admin_views.py
@@ -1,8 +1,10 @@
+from typing import List
+
 from django.views.generic import TemplateView
 
 from bptl.utils.admin import StaffRequiredMixin
 
-from .client import get_xential_client
+from .client import XentialClient, get_xential_clients
 
 
 class TemplatesListView(StaffRequiredMixin, TemplateView):
@@ -13,24 +15,10 @@ class TemplatesListView(StaffRequiredMixin, TemplateView):
         context = super().get_context_data(**kwargs)
 
         template_groups = []
-        template_groups_url = "template_utils/getUsableTemplates"
-        xential_client = get_xential_client()
+        xential_clients = get_xential_clients()
 
-        template_groups_details = xential_client.post(template_groups_url)
-        for template_group in template_groups_details["objects"]:
-            template_group_name = get_name(template_group["fields"])
-            template_group_context = {"name": f"{template_group_name}", "templates": []}
-
-            templates_details = xential_client.post(
-                template_groups_url, params={"parentGroupUuid": template_group["uuid"]}
-            )
-            for template in templates_details["objects"]:
-                template_name = get_name(template["fields"])
-                template_group_context["templates"].append(
-                    {"name": template_name, "uuid": template["uuid"]}
-                )
-
-            template_groups.append(template_group_context)
+        for client in xential_clients:
+            template_groups += get_template_groups(client)
 
         context.update({"template_groups": template_groups})
 
@@ -43,3 +31,31 @@ def get_name(fields: dict) -> str:
             return field["value"]
 
     return "Geen naam"
+
+
+def get_template_groups(xential_client: XentialClient) -> List[dict]:
+    template_groups_url = "template_utils/getUsableTemplates"
+    template_groups_details = xential_client.post(template_groups_url)
+
+    template_groups = []
+
+    for template_group in template_groups_details["objects"]:
+        template_group_name = get_name(template_group["fields"])
+        template_group_context = {
+            "name": template_group_name,
+            "api": xential_client.api_root,
+            "templates": [],
+        }
+
+        templates_details = xential_client.post(
+            template_groups_url, params={"parentGroupUuid": template_group["uuid"]}
+        )
+        for template in templates_details["objects"]:
+            template_name = get_name(template["fields"])
+            template_group_context["templates"].append(
+                {"name": template_name, "uuid": template["uuid"]}
+            )
+
+        template_groups.append(template_group_context)
+
+    return template_groups

--- a/src/bptl/work_units/xential/client.py
+++ b/src/bptl/work_units/xential/client.py
@@ -2,7 +2,7 @@
 Implements a Xential client.
 """
 import logging
-from typing import Dict
+from typing import Dict, List
 
 from django.utils.translation import gettext_lazy as _
 
@@ -61,12 +61,11 @@ def get_client(task: BaseTask, alias: str) -> "JSONClient":
     return _get_client(task, service, cls=client_classes.get(alias))
 
 
-def get_xential_client() -> "XentialClient":
-    default_service = DefaultService.objects.get(alias=XENTIAL_ALIAS)
-    service_credentials = AppServiceCredentials.objects.get(
-        service=default_service.service
-    )
-    client = XentialClient(
-        default_service.service, service_credentials.get_auth_headers()
-    )
-    return client
+def get_xential_clients() -> List["XentialClient"]:
+    services = Service.objects.filter(defaultservice__alias=XENTIAL_ALIAS).distinct()
+    xential_clients = [
+        XentialClient(service, service.build_client().auth_header)
+        for service in services
+    ]
+
+    return xential_clients

--- a/src/bptl/work_units/xential/client.py
+++ b/src/bptl/work_units/xential/client.py
@@ -9,8 +9,7 @@ from django.utils.translation import gettext_lazy as _
 from zgw_consumers.constants import APITypes
 from zgw_consumers.models import Service
 
-from bptl.credentials.models import AppServiceCredentials
-from bptl.tasks.models import BaseTask, DefaultService
+from bptl.tasks.models import BaseTask
 from bptl.tasks.registry import register
 
 from ..clients import JSONClient, get_client as _get_client

--- a/src/bptl/work_units/xential/tests/test_admin_list_templates.py
+++ b/src/bptl/work_units/xential/tests/test_admin_list_templates.py
@@ -1,57 +1,271 @@
-from unittest import skip
-
 from django.urls import reverse_lazy
 
 import requests_mock
 from django_webtest import WebTest
-from zgw_consumers.constants import APITypes
+from zgw_consumers.constants import APITypes, AuthTypes
+from zgw_consumers.models import Service
 
 from bptl.accounts.tests.factories import SuperUserFactory
-from bptl.tasks.tests.factories import DefaultServiceFactory, ServiceFactory
+from bptl.credentials.tests.factories import AppServiceCredentialsFactory
+from bptl.tasks.models import TaskMapping
+from bptl.tasks.tests.factories import DefaultServiceFactory
 
-from ..client import XENTIAL_ALIAS
-
-XENTIAL_API_ROOT = "https://alfresco.nl/xential/s/"
+XENTIAL_API_ROOT = "https://xential.nl/api/"
 
 
-@skip(reason="Needs to be updated to use new Xential endpoint")
 @requests_mock.Mocker()
 class XentialAdminTests(WebTest):
     url = reverse_lazy("xential:templates")
 
-    def test_list_templates(self, m):
-        user = SuperUserFactory.create()
-        xential_service = ServiceFactory.create(
-            api_root=XENTIAL_API_ROOT, api_type=APITypes.orc
-        )
-        DefaultServiceFactory.create(alias=XENTIAL_ALIAS, service=xential_service)
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
 
-        template_data = [
-            {
-                "templateName": "Interactief",
-                "templateUuid": "64de49cf-0ae6-49b1-949c-c65b997d183b",
-            },
-            {
-                "templateName": "Silent",
-                "templateUuid": "9536db06-ca04-4b95-98fe-f1e708f3a90a",
-            },
-        ]
-        m.get(
-            f"{XENTIAL_API_ROOT}xential/templates",
+        mapping = TaskMapping.objects.create(
+            topic_name="xential-topic",
+        )
+        xential = Service.objects.create(
+            label="xential",
+            api_type=APITypes.orc,
+            api_root=XENTIAL_API_ROOT,
+            auth_type=AuthTypes.api_key,
+            oas="",
+        )
+        DefaultServiceFactory.create(
+            task_mapping=mapping,
+            service=xential,
+            alias="xential",
+        )
+        AppServiceCredentialsFactory.create(
+            app__app_id="some-app-id",
+            service=xential,
+            header_key="Authorization",
+            header_value="Basic aGVsbG86dGhpc2lzbm90YXNlY3JldA==",
+        )
+
+    def test_list_templates_context(self, m):
+        user = SuperUserFactory.create()
+
+        m.post(
+            f"{XENTIAL_API_ROOT}auth/whoami",
             json={
-                "data": {
-                    "templates": template_data,
-                    "params": {
-                        "sessionId": "48a8393f-9030-4d71-848d-b3a00126cea3",
-                        "uuid": "9cdfe02e-4a18-4f6c-8816-085b34a9c75c",
-                    },
-                }
+                "user": {
+                    "uuid": "a4664ccb-259e-4107-b800-d8e5a764b9dd",
+                    "userName": "testuser",
+                },
+                "XSessionId": "f7f588eb-b7c9-4d23-babd-4a98a9326367",
+            },
+        )
+        m.post(
+            f"{XENTIAL_API_ROOT}template_utils/getUsableTemplates",
+            json={
+                "objects": [
+                    {
+                        "uuid": "uuid-1",
+                        "objectTypeId": "templategroup",
+                        "fields": [{"name": "name", "value": "Sjablonen"}],
+                    }
+                ]
+            },
+        )
+        m.post(
+            f"{XENTIAL_API_ROOT}template_utils/getUsableTemplates?parentGroupUuid=uuid-1",
+            json={
+                "objects": [
+                    {
+                        "uuid": "uuid-2",
+                        "objectTypeId": "ooxmltexttemplate",
+                        "fields": [{"name": "name", "value": "TestSjabloon"}],
+                    }
+                ]
             },
         )
 
         page = self.app.get(self.url, user=user)
 
         self.assertEqual(page.status_code, 200)
-        self.assertEqual(
-            page.context["template_groups"], {XENTIAL_API_ROOT: template_data}
+        self.assertIn("template_groups", page.context)
+
+        template_group_context = page.context["template_groups"]
+
+        self.assertEqual(1, len(template_group_context))
+
+        template_group = template_group_context[0]
+
+        self.assertEqual("Sjablonen", template_group["name"])
+        self.assertEqual(1, len(template_group["templates"]))
+
+        template = template_group["templates"][0]
+
+        self.assertEqual("TestSjabloon", template["name"])
+        self.assertEqual("uuid-2", template["uuid"])
+
+    def test_list_templates_context_no_names(self, m):
+        user = SuperUserFactory.create()
+
+        m.post(
+            f"{XENTIAL_API_ROOT}auth/whoami",
+            json={
+                "user": {
+                    "uuid": "a4664ccb-259e-4107-b800-d8e5a764b9dd",
+                    "userName": "testuser",
+                },
+                "XSessionId": "f7f588eb-b7c9-4d23-babd-4a98a9326367",
+            },
         )
+        m.post(
+            f"{XENTIAL_API_ROOT}template_utils/getUsableTemplates",
+            json={
+                "objects": [
+                    {"uuid": "uuid-1", "objectTypeId": "templategroup", "fields": []}
+                ]
+            },
+        )
+        m.post(
+            f"{XENTIAL_API_ROOT}template_utils/getUsableTemplates?parentGroupUuid=uuid-1",
+            json={
+                "objects": [
+                    {
+                        "uuid": "uuid-2",
+                        "objectTypeId": "ooxmltexttemplate",
+                        "fields": [],
+                    }
+                ]
+            },
+        )
+
+        page = self.app.get(self.url, user=user)
+
+        self.assertEqual(page.status_code, 200)
+        self.assertIn("template_groups", page.context)
+
+        template_group_context = page.context["template_groups"]
+
+        self.assertEqual(1, len(template_group_context))
+
+        template_group = template_group_context[0]
+
+        self.assertEqual("Geen naam", template_group["name"])
+        self.assertEqual(1, len(template_group["templates"]))
+
+        template = template_group["templates"][0]
+
+        self.assertEqual("Geen naam", template["name"])
+        self.assertEqual("uuid-2", template["uuid"])
+
+    def test_list_templates_context_no_template_groups(self, m):
+        user = SuperUserFactory.create()
+
+        m.post(
+            f"{XENTIAL_API_ROOT}auth/whoami",
+            json={
+                "user": {
+                    "uuid": "a4664ccb-259e-4107-b800-d8e5a764b9dd",
+                    "userName": "testuser",
+                },
+                "XSessionId": "f7f588eb-b7c9-4d23-babd-4a98a9326367",
+            },
+        )
+        m.post(
+            f"{XENTIAL_API_ROOT}template_utils/getUsableTemplates",
+            json={"objects": []},
+        )
+
+        page = self.app.get(self.url, user=user)
+
+        self.assertEqual(page.status_code, 200)
+        self.assertIn("template_groups", page.context)
+
+        template_group_context = page.context["template_groups"]
+
+        self.assertEqual(0, len(template_group_context))
+
+    def test_list_templates_context_no_templates_in_group(self, m):
+        user = SuperUserFactory.create()
+
+        m.post(
+            f"{XENTIAL_API_ROOT}auth/whoami",
+            json={
+                "user": {
+                    "uuid": "a4664ccb-259e-4107-b800-d8e5a764b9dd",
+                    "userName": "testuser",
+                },
+                "XSessionId": "f7f588eb-b7c9-4d23-babd-4a98a9326367",
+            },
+        )
+        m.post(
+            f"{XENTIAL_API_ROOT}template_utils/getUsableTemplates",
+            json={
+                "objects": [
+                    {
+                        "uuid": "uuid-1",
+                        "objectTypeId": "templategroup",
+                        "fields": [{"name": "name", "value": "Sjablonen"}],
+                    }
+                ]
+            },
+        )
+        m.post(
+            f"{XENTIAL_API_ROOT}template_utils/getUsableTemplates?parentGroupUuid=uuid-1",
+            json={"objects": []},
+        )
+
+        page = self.app.get(self.url, user=user)
+
+        self.assertEqual(page.status_code, 200)
+        self.assertIn("template_groups", page.context)
+
+        template_group_context = page.context["template_groups"]
+
+        self.assertEqual(1, len(template_group_context))
+
+        template_group = template_group_context[0]
+
+        self.assertEqual("Sjablonen", template_group["name"])
+        self.assertEqual(0, len(template_group["templates"]))
+
+    def test_rendering_as_table(self, m):
+        user = SuperUserFactory.create()
+
+        m.post(
+            f"{XENTIAL_API_ROOT}auth/whoami",
+            json={
+                "user": {
+                    "uuid": "a4664ccb-259e-4107-b800-d8e5a764b9dd",
+                    "userName": "testuser",
+                },
+                "XSessionId": "f7f588eb-b7c9-4d23-babd-4a98a9326367",
+            },
+        )
+        m.post(
+            f"{XENTIAL_API_ROOT}template_utils/getUsableTemplates",
+            json={
+                "objects": [
+                    {
+                        "uuid": "uuid-1",
+                        "objectTypeId": "templategroup",
+                        "fields": [{"name": "name", "value": "Sjablonen"}],
+                    }
+                ]
+            },
+        )
+        m.post(
+            f"{XENTIAL_API_ROOT}template_utils/getUsableTemplates?parentGroupUuid=uuid-1",
+            json={
+                "objects": [
+                    {
+                        "uuid": "uuid-2",
+                        "objectTypeId": "ooxmltexttemplate",
+                        "fields": [{"name": "name", "value": "TestSjabloon"}],
+                    }
+                ]
+            },
+        )
+
+        page = self.app.get(self.url, user=user)
+
+        self.assertEqual("Template Group Sjablonen", page.html.h2.text)
+        self.assertIn("Template name", page.html.table.thead.tr.text)
+        self.assertIn("UUID", page.html.table.thead.tr.text)
+        self.assertIn("TestSjabloon", page.html.table.tbody.tr.text)
+        self.assertIn("uuid-2", page.html.table.tbody.tr.text)

--- a/src/bptl/work_units/xential/tests/test_admin_list_templates.py
+++ b/src/bptl/work_units/xential/tests/test_admin_list_templates.py
@@ -2,12 +2,9 @@ from django.urls import reverse_lazy
 
 import requests_mock
 from django_webtest import WebTest
-from zgw_consumers.constants import APITypes, AuthTypes
-from zgw_consumers.models import Service
+from zgw_consumers.constants import APITypes
 
 from bptl.accounts.tests.factories import SuperUserFactory
-from bptl.credentials.tests.factories import AppServiceCredentialsFactory
-from bptl.tasks.models import TaskMapping
 from bptl.tasks.tests.factories import (
     DefaultServiceFactory,
     ServiceFactory,


### PR DESCRIPTION
Fixes #116 

Each template group from Xential is now shown as a table in the admin (I used the same template that was used for the Alfresco endpoint).
Each table row shows the name and the uuid of the template.