### PR TITLE
Build xential document silently

### DIFF
--- a/src/bptl/work_units/xential/tasks.py
+++ b/src/bptl/work_units/xential/tasks.py
@@ -157,7 +157,7 @@ def start_xential_template(task: BaseTask) -> dict:
         # Step 3: Build document silently
         # If not all template variables are filled, building the document will not work.
         build_document_url = "document/buildDocument"
-        params = {"documentUuid": document_uuid}
+        params = {"documentUuid": document_uuid, "close": "true"}
         xential_client.post(build_document_url, params=params)
 
         ticket.document_uuid = document_uuid


### PR DESCRIPTION
The discussion with Xential showed that we were missing the query parameter `close` when building the document silently.

After adding this parameter, no 500 error happens anymore when building the document. 