### PR TITLE
Added logging to debug Xential callback

### DIFF
--- a/src/bptl/work_units/xential/views.py
+++ b/src/bptl/work_units/xential/views.py
@@ -30,6 +30,10 @@ class DocumentCreationCallbackView(views.APIView):
     parser_classes = [SnakeXMLParser]
 
     def post(self, request: Request) -> Response:
+        logger.error("Response data: %s", request.data)
+        logger.error("Ticket UUID: %s", request.data.get("bptl_ticket_uuid"))
+        logger.error("Xential Document b64: %s", request.data.get("document"))
+
         # The callback sends the base64 encoded document and the BPTL ticket ID as XML.
         serializer = CallbackDataSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -59,6 +63,7 @@ class DocumentCreationCallbackView(views.APIView):
         document = drc_client.post(
             "enkelvoudiginformatieobjecten", json=document_properties
         )
+        logger.error("Xential callback created: %s", document["url"])
 
         # Notify camunda that the document has been created
         on_document_created(task, document["url"])


### PR DESCRIPTION
Since the callback from Xential to the endpoint is failing validation, I added logging to see what is going on.