### PR TITLE
Skip eigenschap creation if value is empty

### DIFF
--- a/src/bptl/work_units/zgw/tasks/zaak_relations.py
+++ b/src/bptl/work_units/zgw/tasks/zaak_relations.py
@@ -201,7 +201,12 @@ class CreateEigenschap(ZGWWorkUnit):
             return {}
 
         naam = check_variable(eigenschap, "naam")
-        waarde = check_variable(eigenschap, "waarde")
+        waarde = check_variable(eigenschap, "waarde", empty_allowed=True)
+        if not waarde:
+            logger.info(
+                "Skipping creation of eigenschap %s, empty value provided", naam
+            )
+            return {}
 
         # fetch zaaktype - either from process variable or derive from zaak
         zaaktype = variables.get("zaaktype")

--- a/src/bptl/work_units/zgw/tests/test_eigenschappen.py
+++ b/src/bptl/work_units/zgw/tests/test_eigenschappen.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from django.test import TestCase
 
 import requests_mock
@@ -142,3 +144,30 @@ class CreateDocumentRelationTaskTests(TestCase):
         task.perform()
 
         self.assertTrue(all(req.method == "GET" for req in m.request_history))
+
+    def test_eigenschap_value_missing_skip(self, m):
+        task = ExternalTask.objects.create(
+            topic_name="some-topic",
+            worker_id="test-worker-id",
+            task_id="test-task-id",
+            variables={
+                "services": serialize_variable(
+                    {
+                        "ZRC": {"jwt": "Bearer 12345"},
+                        "ZTC": {"jwt": "Bearer 12345"},
+                    }
+                ),
+                "zaakUrl": serialize_variable(ZAAK),
+                "eigenschap": serialize_variable(
+                    {
+                        "naam": "start",
+                        "waarde": "",
+                    }
+                ),
+            },
+        )
+
+        task = CreateEigenschap(task)
+        task.perform()
+
+        self.assertFalse(m.called)


### PR DESCRIPTION
This can happen if certain properties are marked as optional.