### PR TITLE
:bug: Fix pluralization for Objects/Objecttypes APIs

### DIFF
--- a/src/bptl/work_units/zgw/client.py
+++ b/src/bptl/work_units/zgw/client.py
@@ -191,8 +191,8 @@ class ZGWClient(APIClient):
 
         resource, action = parts
 
-        # Apply pluralization rules for Dutch ZGW APIs
-        resource_plural = resource  # self._pluralize(resource)
+        # Apply pluralization rules for ZGW APIs
+        resource_plural = self._pluralize(resource)
 
         method_map = {
             "list": ("GET", f"{resource_plural}"),
@@ -239,8 +239,8 @@ class ZGWClient(APIClient):
             "rol": "rollen",
             "eigenschap": "eigenschappen",
             "zaakeigenschap": "zaakeigenschappen",
-            "object": "objecten",
-            "objecttype": "objecttypen",
+            "object": "objects",
+            "objecttype": "objecttypes",
             "besluit": "besluiten",
             "besluittype": "besluittypen",
             "document": "documenten",


### PR DESCRIPTION
- Re-enable pluralization in _infer_operation_url (was commented out)
- Update pluralization map to use English plurals for object/objecttype since the Objects API and Objecttypes API use English endpoints (/objects, /objecttypes) not Dutch (/objecten, /objecttypen)